### PR TITLE
feat: spot runs (triggerless pipelines)

### DIFF
--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -34,8 +34,9 @@ type PipelineSpec struct {
 	Repos []RepoCandidate `json:"repos,omitempty"`
 
 	// trigger configures how new pipeline runs are created.
-	// +required
-	Trigger TriggerSpec `json:"trigger"`
+	// If omitted, the pipeline only supports spot runs (manual creation).
+	// +optional
+	Trigger *TriggerSpec `json:"trigger,omitempty"`
 
 	// ai configures the AI runtime (container image, env, secrets).
 	// +required

--- a/api/v1alpha1/pipelinerun_types.go
+++ b/api/v1alpha1/pipelinerun_types.go
@@ -26,17 +26,21 @@ type PipelineRunSpec struct {
 	// +required
 	PipelineRef string `json:"pipelineRef"`
 
+	// description is the task description for spot runs (runs without a trigger event).
+	// +optional
+	Description string `json:"description,omitempty"`
+
 	// issueNumber is the issue number that triggered this run.
-	// +required
-	IssueNumber int `json:"issueNumber"`
+	// +optional
+	IssueNumber int `json:"issueNumber,omitempty"`
 
 	// issueKey is the issue identifier (e.g. "PROJ-123" for Jira, "#1" for GitHub).
 	// +optional
 	IssueKey string `json:"issueKey,omitempty"`
 
 	// issueTitle is the title/summary of the triggering issue.
-	// +required
-	IssueTitle string `json:"issueTitle"`
+	// +optional
+	IssueTitle string `json:"issueTitle,omitempty"`
 
 	// issueBody is the body/description of the triggering issue.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -289,7 +289,11 @@ func (in *PipelineSpec) DeepCopyInto(out *PipelineSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.Trigger.DeepCopyInto(&out.Trigger)
+	if in.Trigger != nil {
+		in, out := &in.Trigger, &out.Trigger
+		*out = new(TriggerSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	in.AI.DeepCopyInto(&out.AI)
 	if in.Steps != nil {
 		in, out := &in.Steps, &out.Steps

--- a/config/crd/bases/ai.aipipelines.io_pipelineruns.yaml
+++ b/config/crd/bases/ai.aipipelines.io_pipelineruns.yaml
@@ -63,6 +63,10 @@ spec:
                   approvedStep is set by the dashboard to approve a step that has requireApproval.
                   The controller checks this against the current waiting step to resume.
                 type: string
+              description:
+                description: description is the task description for spot runs (runs
+                  without a trigger event).
+                type: string
               issueBody:
                 description: issueBody is the body/description of the triggering issue.
                 type: string
@@ -100,8 +104,6 @@ spec:
                 - owner
                 type: object
             required:
-            - issueNumber
-            - issueTitle
             - pipelineRef
             type: object
           status:

--- a/config/crd/bases/ai.aipipelines.io_pipelines.yaml
+++ b/config/crd/bases/ai.aipipelines.io_pipelines.yaml
@@ -240,7 +240,9 @@ spec:
                 minItems: 1
                 type: array
               trigger:
-                description: trigger configures how new pipeline runs are created.
+                description: |-
+                  trigger configures how new pipeline runs are created.
+                  If omitted, the pipeline only supports spot runs (manual creation).
                 properties:
                   github:
                     description: github configures GitHub Issues polling.
@@ -330,7 +332,6 @@ spec:
             required:
             - ai
             - steps
-            - trigger
             type: object
           status:
             description: PipelineStatus defines the observed state of Pipeline.

--- a/config/samples/ai_v1alpha1_pipeline_spot.yaml
+++ b/config/samples/ai_v1alpha1_pipeline_spot.yaml
@@ -1,0 +1,133 @@
+apiVersion: ai.aipipelines.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: my-spot-pipeline
+  namespace: default
+spec:
+  # No trigger — runs are created manually via the dashboard with a task description.
+
+  repo:
+    owner: "your-github-org"
+    name: "your-repo"
+    forkOwner: "your-github-username"
+    secretRef:
+      name: github-token
+
+  ai:
+    image: "localhost/ai-pipelines-claude:latest"
+    env:
+      # Anthropic API key (direct)
+      # ANTHROPIC_API_KEY is read from the secret referenced below (ai-credentials)
+
+      # --- OR use Vertex AI ---
+      # CLAUDE_CODE_USE_VERTEX: "1"
+      # ANTHROPIC_VERTEX_PROJECT_ID: "your-gcp-project-id"
+      # CLOUD_ML_REGION: "us-east5"
+      # GOOGLE_APPLICATION_CREDENTIALS: "/tmp/gcp-creds.json"
+      # GCE_METADATA_HOST: "localhost"  # only needed outside GCP VMs
+    secretRef:
+      name: ai-credentials
+      key: credentials.json
+    credentialsMountPath: "/tmp/gcp-creds.json"
+    imagePullPolicy: Never
+
+  steps:
+    - name: checkout
+      type: git-checkout
+      branchTemplate: "ai/spot-{{.Timestamp}}"
+
+    - name: write-tests
+      type: ai
+      dind: true
+      promptTemplate: |
+        {{.Description}}
+
+        ENVIRONMENT SETUP:
+        Before starting, check the repository's README.md, AGENTS.md, and Makefile to determine
+        what language/tools are needed. Install any missing dependencies:
+        - Go: download from https://go.dev/dl/ and install to /usr/local/go, add to PATH
+        - Node.js: use `curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs`
+        - Python: `apt-get update && apt-get install -y python3 python3-pip`
+        - For other tools, install as appropriate
+        Docker is available if needed.
+
+        TASK:
+        You are on branch `{{.Branch}}`. Stay on this branch — do NOT switch to main or any other branch.
+        Your task is to write tests that verify the requirements described above.
+        Look at the existing test patterns in the codebase and follow them.
+        If there is a Makefile, check the available test targets for conventions.
+        The tests should FAIL at this point — the implementation does not exist yet.
+        Do NOT implement the feature — only write the tests.
+        Do NOT run git add, git commit, or git push — the pipeline handles all git operations separately.
+
+    - name: implement
+      type: ai
+      promptTemplate: |
+        {{.Description}}
+
+        ENVIRONMENT SETUP:
+        Before starting, check the repository's README.md, AGENTS.md, and Makefile to determine
+        what language/tools are needed. Install any missing dependencies:
+        - Go: download from https://go.dev/dl/ and install to /usr/local/go, add to PATH
+        - Node.js: use `curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs`
+        - Python: `apt-get update && apt-get install -y python3 python3-pip`
+        - For other tools, install as appropriate
+
+        TASK:
+        You are on branch `{{.Branch}}`. Stay on this branch — do NOT switch to main or any other branch.
+        Tests have already been written for this task. Make the changes to satisfy the
+        requirements and make the tests pass.
+
+        If the file `/workspace/.test-failures.md` exists, read it first — it contains the output
+        from a previous test run that failed. Use it to understand exactly what is broken and fix it.
+
+        Do NOT modify the test files.
+        Do NOT run git add, git commit, or git push — the pipeline handles all git operations separately.
+
+    - name: test
+      type: ai
+      dind: true
+      failureFile: /workspace/.test-failures.md
+      onFailure: implement
+      maxRetries: 3
+      promptTemplate: |
+        You are on branch `{{.Branch}}`. Your only task is to run the existing tests for this repository.
+
+        ENVIRONMENT SETUP:
+        You have Docker available. Before running tests, you MUST set up the required toolchain.
+        Check the repository's README.md, AGENTS.md, and Makefile to determine what language/tools
+        are needed, then install any missing dependencies:
+        - Go: download from https://go.dev/dl/ and install to /usr/local/go, add to PATH
+        - Node.js: use `curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs`
+        - Python: `apt-get update && apt-get install -y python3 python3-pip`
+        - For other tools, install as appropriate
+        You can also use Docker to run tests if the project uses container-based testing (Kind, docker-compose, etc).
+
+        TESTING:
+        Check for testing instructions in these files (in order of priority):
+        1. AGENTS.md or CLAUDE.md (AI-specific instructions)
+        2. Makefile (look for test targets like `make test`, `make check`, `make verify`)
+        3. README.md (testing section)
+        4. package.json (for `npm test` or similar)
+
+        Run the appropriate test commands.
+
+        IMPORTANT: Run test packages/suites SEQUENTIALLY, not in parallel. The Docker-in-Docker
+        environment has limited resources and running tests in parallel can exhaust process limits,
+        causing spurious failures. Use flags like `go test -p 1` (Go), `--runInBand` (Jest), or
+        equivalent sequential options for your test runner.
+
+        If ALL tests pass, make sure `/workspace/.test-failures.md` does NOT exist (delete it if present).
+
+        If ANY test fails, write a detailed failure report to `/workspace/.test-failures.md` containing:
+        - The exact commands that were run
+        - The full error output
+        - Which tests failed and why
+        Then stop — do not attempt to fix anything.
+
+        Do NOT modify any source code — only run tests and report results.
+        Do NOT run git add, git commit, or git push.
+
+    - name: push
+      type: git-push
+      requireApproval: true

--- a/dashboard/src/pages/PipelineDetail.tsx
+++ b/dashboard/src/pages/PipelineDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
-import type { PipelineRun } from '../types/api'
+import type { Pipeline, PipelineRun } from '../types/api'
 import StatusBadge from '../components/StatusBadge'
 import TimeAgo from '../components/TimeAgo'
 import RetryButton from '../components/RetryButton'
@@ -12,11 +12,22 @@ const PAGE_SIZE = 20
 
 export default function PipelineDetail() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>()
+  const [pipeline, setPipeline] = useState<Pipeline | null>(null)
   const [runs, setRuns] = useState<PipelineRun[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [activeOnly, setActiveOnly] = useState(false)
   const [page, setPage] = useState(0)
+  const [showCreate, setShowCreate] = useState(false)
+  const [description, setDescription] = useState('')
+  const [creating, setCreating] = useState(false)
+
+  useEffect(() => {
+    fetch(`/api/pipelines/${namespace}/${name}`)
+      .then(r => r.ok ? r.json() : null)
+      .then(setPipeline)
+      .catch(() => {})
+  }, [namespace, name])
 
   useEffect(() => {
     const load = async () => {
@@ -35,6 +46,27 @@ export default function PipelineDetail() {
     return () => clearInterval(id)
   }, [namespace, name])
 
+  const handleCreateRun = async () => {
+    if (!description.trim()) return
+    setCreating(true)
+    try {
+      const res = await fetch(`/api/pipelines/${namespace}/${name}/runs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: description.trim() }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      setShowCreate(false)
+      setDescription('')
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to create run')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const isSpot = pipeline?.triggerType === 'Spot'
+
   if (loading) return <div className="text-gray-400 py-12">Loading runs...</div>
   if (error) return <div className="text-red-400 py-12">{error}</div>
 
@@ -50,18 +82,56 @@ export default function PipelineDetail() {
           <span className="text-gray-600">/</span>
           <h1 className="text-2xl font-semibold">{name}</h1>
         </div>
-        <button
-          onClick={() => { setActiveOnly(!activeOnly); setPage(0) }}
-          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
-            activeOnly
-              ? 'bg-indigo-500/15 text-indigo-400 border-indigo-500/30'
-              : 'bg-gray-800/50 text-gray-500 border-gray-700 hover:text-gray-400 hover:border-gray-600'
-          }`}
-        >
-          <span className={`inline-block w-1.5 h-1.5 rounded-full ${activeOnly ? 'bg-indigo-400' : 'bg-gray-600'}`} />
-          Active only
-        </button>
+        <div className="flex items-center gap-3">
+          {isSpot && (
+            <button
+              onClick={() => setShowCreate(true)}
+              className="px-3 py-1.5 rounded-lg text-xs font-medium bg-indigo-600 text-white hover:bg-indigo-500 transition-colors"
+            >
+              Create Run
+            </button>
+          )}
+          <button
+            onClick={() => { setActiveOnly(!activeOnly); setPage(0) }}
+            className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+              activeOnly
+                ? 'bg-indigo-500/15 text-indigo-400 border-indigo-500/30'
+                : 'bg-gray-800/50 text-gray-500 border-gray-700 hover:text-gray-400 hover:border-gray-600'
+            }`}
+          >
+            <span className={`inline-block w-1.5 h-1.5 rounded-full ${activeOnly ? 'bg-indigo-400' : 'bg-gray-600'}`} />
+            Active only
+          </button>
+        </div>
       </div>
+
+      {showCreate && (
+        <div className="mb-6 p-4 rounded-lg border border-gray-700 bg-gray-900/50">
+          <h3 className="text-sm font-medium text-gray-300 mb-2">Create Spot Run</h3>
+          <textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Describe the task..."
+            rows={3}
+            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-indigo-500 resize-none"
+          />
+          <div className="flex justify-end gap-2 mt-2">
+            <button
+              onClick={() => { setShowCreate(false); setDescription('') }}
+              className="px-3 py-1.5 rounded text-xs text-gray-400 hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreateRun}
+              disabled={creating || !description.trim()}
+              className="px-3 py-1.5 rounded-lg text-xs font-medium bg-indigo-600 text-white hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              {creating ? 'Creating...' : 'Create'}
+            </button>
+          </div>
+        </div>
+      )}
 
       {!filtered.length ? (
         <div className="text-gray-500 py-12">{activeOnly ? 'No active runs.' : 'No runs yet.'}</div>
@@ -88,8 +158,14 @@ export default function PipelineDetail() {
                     </Link>
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-gray-300">{r.issueKey || `#${r.issueNumber}`}</span>
-                    <span className="text-gray-500 ml-2 truncate max-w-xs inline-block align-bottom">{r.issueTitle}</span>
+                    {r.issueKey || r.issueNumber ? (
+                      <>
+                        <span className="text-gray-300">{r.issueKey || `#${r.issueNumber}`}</span>
+                        <span className="text-gray-500 ml-2 truncate max-w-xs inline-block align-bottom">{r.issueTitle}</span>
+                      </>
+                    ) : (
+                      <span className="text-gray-400 truncate max-w-xs inline-block align-bottom">{r.description || 'Spot run'}</span>
+                    )}
                   </td>
                   <td className="px-4 py-3"><StatusBadge status={r.phase} /></td>
                   <td className="px-4 py-3 text-gray-400">{r.currentStep || '—'}</td>

--- a/dashboard/src/pages/PipelineList.tsx
+++ b/dashboard/src/pages/PipelineList.tsx
@@ -108,7 +108,11 @@ export default function PipelineList() {
                   <div>
                     <h2 className="text-lg font-medium text-white">{p.name}</h2>
                     <p className="text-sm text-gray-400 mt-1">
-                      <span className="text-gray-500">{p.triggerType}:</span> {p.triggerInfo}
+                      {p.triggerType === 'Spot' ? (
+                        <span className="text-gray-500">{p.triggerInfo}</span>
+                      ) : (
+                        <><span className="text-gray-500">{p.triggerType}:</span> {p.triggerInfo}</>
+                      )}
                     </p>
                     {p.triggerJql && (
                       <p className="mt-1.5 text-xs text-gray-500 font-mono bg-gray-800/50 rounded px-2 py-1 inline-block max-w-xl truncate" title={p.triggerJql}>
@@ -152,7 +156,11 @@ export default function PipelineList() {
                             </Link>
                           </td>
                           <td className="px-3 py-2.5 text-gray-400">
-                            {r.issueKey || `#${r.issueNumber}`} <span className="text-gray-500 truncate max-w-48 inline-block align-bottom">{r.issueTitle}</span>
+                            {r.issueKey || r.issueNumber ? (
+                              <>{r.issueKey || `#${r.issueNumber}`} <span className="text-gray-500 truncate max-w-48 inline-block align-bottom">{r.issueTitle}</span></>
+                            ) : (
+                              <span className="text-gray-500 truncate max-w-48 inline-block align-bottom">{r.description || 'Spot run'}</span>
+                            )}
                           </td>
                           <td className="px-3 py-2.5"><StatusBadge status={r.phase} /></td>
                           <td className="px-3 py-2.5 text-gray-500 text-xs">{r.currentStep || '—'}</td>

--- a/dashboard/src/pages/RunDetail.tsx
+++ b/dashboard/src/pages/RunDetail.tsx
@@ -454,7 +454,8 @@ export default function RunDetail() {
   if (error) return <div className="text-red-400 py-12">{error}</div>
   if (!run) return null
 
-  const issueRef = run.issueKey || `#${run.issueNumber}`
+  const issueRef = run.issueKey || (run.issueNumber ? `#${run.issueNumber}` : '')
+  const isSpotRun = !issueRef
   const isTerminal = run.phase === 'Succeeded' || run.phase === 'Failed' || run.phase === 'Stopped' || run.phase === 'Deleting'
 
   return (
@@ -478,8 +479,17 @@ export default function RunDetail() {
 
       <div className="flex flex-wrap gap-6 mb-6 text-sm text-gray-400">
         <div>
-          <span className="text-gray-500">Issue:</span>{' '}
-          <span className="text-gray-200">{issueRef} {run.issueTitle}</span>
+          {isSpotRun ? (
+            <>
+              <span className="text-gray-500">Task:</span>{' '}
+              <span className="text-gray-200">{run.description || 'Spot run'}</span>
+            </>
+          ) : (
+            <>
+              <span className="text-gray-500">Issue:</span>{' '}
+              <span className="text-gray-200">{issueRef} {run.issueTitle}</span>
+            </>
+          )}
         </div>
         {run.resolvedRepo && (
           <div>

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -25,6 +25,7 @@ export interface PipelineRun {
   name: string;
   namespace: string;
   pipeline: string;
+  description?: string;
   issueNumber: number;
   issueKey: string;
   issueTitle: string;

--- a/internal/controller/pipeline_controller.go
+++ b/internal/controller/pipeline_controller.go
@@ -68,7 +68,19 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	trig := pipeline.Spec.Trigger
+	// No trigger configured — pipeline only supports spot runs
+	if pipeline.Spec.Trigger == nil {
+		r.stopPoller(req.NamespacedName)
+		pipeline.Status.PollerActive = false
+		if err := r.Status().Update(ctx, &pipeline); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	trig := *pipeline.Spec.Trigger
 
 	// Read trigger credentials from Secret
 	var secretRef aiv1alpha1.SecretKeyRef

--- a/internal/controller/pipeline_controller_test.go
+++ b/internal/controller/pipeline_controller_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Pipeline Controller", func() {
 						Namespace: "default",
 					},
 					Spec: aiv1alpha1.PipelineSpec{
-						Trigger: aiv1alpha1.TriggerSpec{
+						Trigger: &aiv1alpha1.TriggerSpec{
 							GitHub: &aiv1alpha1.GitHubTriggerSpec{
 								Owner:    "test-owner",
 								Repo:     "test-repo",
@@ -97,8 +97,68 @@ var _ = Describe("Pipeline Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+
+	Context("When reconciling a spot (triggerless) pipeline", func() {
+		const spotName = "test-spot-pipeline"
+
+		ctx := context.Background()
+
+		spotKey := types.NamespacedName{
+			Name:      spotName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			resource := &aiv1alpha1.Pipeline{}
+			err := k8sClient.Get(ctx, spotKey, resource)
+			if err != nil && errors.IsNotFound(err) {
+				resource = &aiv1alpha1.Pipeline{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      spotName,
+						Namespace: "default",
+					},
+					Spec: aiv1alpha1.PipelineSpec{
+						// No Trigger — spot-run-only pipeline
+						AI: aiv1alpha1.AISpec{
+							Image: "test-image:latest",
+						},
+						Steps: []aiv1alpha1.StepSpec{
+							{
+								Name: "checkout",
+								Type: "git-checkout",
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			resource := &aiv1alpha1.Pipeline{}
+			err := k8sClient.Get(ctx, spotKey, resource)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+
+		It("should reconcile without starting a poller", func() {
+			controllerReconciler := &PipelineReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: spotKey,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			// Verify no poller was started
+			var updated aiv1alpha1.Pipeline
+			Expect(k8sClient.Get(ctx, spotKey, &updated)).To(Succeed())
+			Expect(updated.Status.PollerActive).To(BeFalse())
 		})
 	})
 })

--- a/internal/controller/pipelinerun_controller.go
+++ b/internal/controller/pipelinerun_controller.go
@@ -557,8 +557,11 @@ func (r *PipelineRunReconciler) recordCompletion(ctx context.Context, run *aiv1a
 		return
 	}
 	issueKey := run.Spec.IssueKey
-	if issueKey == "" {
+	if issueKey == "" && run.Spec.IssueNumber > 0 {
 		issueKey = fmt.Sprintf("#%d", run.Spec.IssueNumber)
+	}
+	if issueKey == "" {
+		issueKey = "spot:" + run.Name
 	}
 	completedAt := time.Now()
 	if run.Status.FinishedAt != nil {
@@ -1125,8 +1128,19 @@ func (r *PipelineRunReconciler) configurePushJob(_ context.Context, job *batchv1
 	branch := run.Status.Branch
 
 	issueRef := run.Spec.IssueKey
-	if issueRef == "" {
+	if issueRef == "" && run.Spec.IssueNumber > 0 {
 		issueRef = fmt.Sprintf("#%d", run.Spec.IssueNumber)
+	}
+
+	var commitMsg string
+	if issueRef != "" {
+		commitMsg = fmt.Sprintf("ai: implement issue %s - %s", issueRef, run.Spec.IssueTitle)
+	} else {
+		desc := run.Spec.Description
+		if len(desc) > 72 {
+			desc = desc[:72]
+		}
+		commitMsg = fmt.Sprintf("ai: %s", desc)
 	}
 
 	// Re-inject credentials into the fork remote (stripped during checkout),
@@ -1149,13 +1163,13 @@ if git diff --cached --quiet; then
   echo "no changes to commit"
   exit 0
 fi
-git commit -m 'ai: implement issue %s - %s'
+git commit -m '%s'
 git push -u fork %s
 echo "pushed branch %s to fork"`,
 		workspacePath, workspacePath,
 		forkOwner, repo.Name,
 		branch, branch,
-		issueRef, run.Spec.IssueTitle,
+		commitMsg,
 		branch, branch)
 
 	job.Spec.Template.Spec.Containers = []corev1.Container{
@@ -1399,6 +1413,7 @@ type templateData struct {
 	IssueKey       string
 	IssueTitle     string
 	IssueBody      string
+	Description    string
 	Branch         string
 	Timestamp      string
 	RepoCandidates []repoCandidateData
@@ -1418,6 +1433,7 @@ func newTemplateData(run *aiv1alpha1.PipelineRun, repos []aiv1alpha1.RepoCandida
 		IssueKey:    run.Spec.IssueKey,
 		IssueTitle:  run.Spec.IssueTitle,
 		IssueBody:   run.Spec.IssueBody,
+		Description: run.Spec.Description,
 		Branch:      run.Status.Branch,
 		Timestamp:   run.CreationTimestamp.Format("20060102T1504"),
 	}

--- a/internal/controller/pipelinerun_controller_test.go
+++ b/internal/controller/pipelinerun_controller_test.go
@@ -77,8 +77,54 @@ var _ = Describe("PipelineRun Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+
+	Context("When reconciling a spot run", func() {
+		const spotRunName = "test-spot-run"
+
+		ctx := context.Background()
+
+		spotKey := types.NamespacedName{
+			Name:      spotRunName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			resource := &aiv1alpha1.PipelineRun{}
+			err := k8sClient.Get(ctx, spotKey, resource)
+			if err != nil && errors.IsNotFound(err) {
+				resource = &aiv1alpha1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      spotRunName,
+						Namespace: "default",
+						Labels: map[string]string{
+							"ai.aipipelines.io/spot": "true",
+						},
+					},
+					Spec: aiv1alpha1.PipelineRunSpec{
+						PipelineRef: "test-pipeline",
+						Description: "Fix the login bug on the settings page",
+					},
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			resource := &aiv1alpha1.PipelineRun{}
+			err := k8sClient.Get(ctx, spotKey, resource)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+
+		It("should create a spot run without issue fields", func() {
+			var run aiv1alpha1.PipelineRun
+			Expect(k8sClient.Get(ctx, spotKey, &run)).To(Succeed())
+			Expect(run.Spec.Description).To(Equal("Fix the login bug on the settings page"))
+			Expect(run.Spec.IssueNumber).To(Equal(0))
+			Expect(run.Spec.IssueKey).To(BeEmpty())
+			Expect(run.Spec.IssueTitle).To(BeEmpty())
 		})
 	})
 })

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -77,6 +77,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("PUT /api/pipelines/{namespace}/{name}", s.handleUpdatePipeline)
 	mux.HandleFunc("DELETE /api/pipelines/{namespace}/{name}", s.handleDeletePipeline)
 	mux.HandleFunc("GET /api/pipelines/{namespace}/{name}/runs", s.handleListRuns)
+	mux.HandleFunc("POST /api/pipelines/{namespace}/{name}/runs", s.handleCreateRun)
 	mux.HandleFunc("GET /api/pipelines/{namespace}/{name}/repos", s.handleListRepos)
 	mux.HandleFunc("GET /api/runs/{namespace}/{name}", s.handleGetRun)
 	mux.HandleFunc("GET /api/runs/{namespace}/{name}/steps/{step}/logs", s.handleGetLogs)
@@ -138,6 +139,7 @@ type runResponse struct {
 	Name            string                   `json:"name"`
 	Namespace       string                   `json:"namespace"`
 	Pipeline        string                   `json:"pipeline"`
+	Description     string                   `json:"description,omitempty"`
 	IssueNumber     int                      `json:"issueNumber"`
 	IssueKey        string                   `json:"issueKey"`
 	IssueTitle      string                   `json:"issueTitle"`
@@ -200,16 +202,21 @@ func (s *Server) handleListPipelines(w http.ResponseWriter, r *http.Request) {
 			ActiveRuns: counts[0],
 			TotalRuns:  counts[1],
 		}
-		switch {
-		case p.Spec.Trigger.GitHub != nil:
-			resp.TriggerType = "GitHub"
-			resp.TriggerInfo = fmt.Sprintf("%s/%s (assignee: %s)", p.Spec.Trigger.GitHub.Owner, p.Spec.Trigger.GitHub.Repo, p.Spec.Trigger.GitHub.Assignee)
-			resp.PollInterval = p.Spec.Trigger.GitHub.PollInterval
-		case p.Spec.Trigger.Jira != nil:
-			resp.TriggerType = "Jira"
-			resp.TriggerInfo = p.Spec.Trigger.Jira.URL
-			resp.TriggerJQL = p.Spec.Trigger.Jira.JQL
-			resp.PollInterval = p.Spec.Trigger.Jira.PollInterval
+		if p.Spec.Trigger == nil {
+			resp.TriggerType = "Spot"
+			resp.TriggerInfo = "Manual runs only"
+		} else {
+			switch {
+			case p.Spec.Trigger.GitHub != nil:
+				resp.TriggerType = "GitHub"
+				resp.TriggerInfo = fmt.Sprintf("%s/%s (assignee: %s)", p.Spec.Trigger.GitHub.Owner, p.Spec.Trigger.GitHub.Repo, p.Spec.Trigger.GitHub.Assignee)
+				resp.PollInterval = p.Spec.Trigger.GitHub.PollInterval
+			case p.Spec.Trigger.Jira != nil:
+				resp.TriggerType = "Jira"
+				resp.TriggerInfo = p.Spec.Trigger.Jira.URL
+				resp.TriggerJQL = p.Spec.Trigger.Jira.JQL
+				resp.PollInterval = p.Spec.Trigger.Jira.PollInterval
+			}
 		}
 		out = append(out, resp)
 	}
@@ -227,14 +234,26 @@ func (s *Server) handleGetPipeline(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	triggerType := "Spot"
+	if pipeline.Spec.Trigger != nil {
+		switch {
+		case pipeline.Spec.Trigger.GitHub != nil:
+			triggerType = "GitHub"
+		case pipeline.Spec.Trigger.Jira != nil:
+			triggerType = "Jira"
+		}
+	}
+
 	writeJSON(w, struct {
-		Name      string                  `json:"name"`
-		Namespace string                  `json:"namespace"`
-		Spec      aiv1alpha1.PipelineSpec `json:"spec"`
+		Name        string                  `json:"name"`
+		Namespace   string                  `json:"namespace"`
+		TriggerType string                  `json:"triggerType"`
+		Spec        aiv1alpha1.PipelineSpec `json:"spec"`
 	}{
-		Name:      pipeline.Name,
-		Namespace: pipeline.Namespace,
-		Spec:      pipeline.Spec,
+		Name:        pipeline.Name,
+		Namespace:   pipeline.Namespace,
+		TriggerType: triggerType,
+		Spec:        pipeline.Spec,
 	})
 }
 
@@ -383,6 +402,66 @@ func (s *Server) handleListRuns(w http.ResponseWriter, r *http.Request) {
 	})
 
 	writeJSON(w, out)
+}
+
+func (s *Server) handleCreateRun(w http.ResponseWriter, r *http.Request) {
+	namespace := r.PathValue("namespace")
+	name := r.PathValue("name")
+
+	var body struct {
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+	if body.Description == "" {
+		http.Error(w, "description is required", http.StatusBadRequest)
+		return
+	}
+
+	var pipeline aiv1alpha1.Pipeline
+	if err := s.k8s.Get(r.Context(), client.ObjectKey{Namespace: namespace, Name: name}, &pipeline); err != nil {
+		http.Error(w, fmt.Sprintf("pipeline not found: %v", err), http.StatusNotFound)
+		return
+	}
+
+	if pipeline.Spec.Trigger != nil {
+		http.Error(w, "spot runs are only supported for pipelines without a trigger", http.StatusBadRequest)
+		return
+	}
+
+	run := &aiv1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("%s-spot-", name),
+			Namespace:    namespace,
+			Labels: map[string]string{
+				"ai.aipipelines.io/pipeline": name,
+				"ai.aipipelines.io/spot":     "true",
+			},
+		},
+		Spec: aiv1alpha1.PipelineRunSpec{
+			PipelineRef: name,
+			Description: body.Description,
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(&pipeline, run, s.k8s.Scheme()); err != nil {
+		http.Error(w, fmt.Sprintf("failed to set owner reference: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	if err := s.k8s.Create(r.Context(), run); err != nil {
+		http.Error(w, fmt.Sprintf("failed to create run: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, map[string]string{
+		"status":    "created",
+		"name":      run.Name,
+		"namespace": run.Namespace,
+	})
 }
 
 func (s *Server) handleGetRun(w http.ResponseWriter, r *http.Request) {
@@ -721,6 +800,12 @@ func (s *Server) handlePendingIssues(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// No trigger — spot-run-only pipeline
+	if pipeline.Spec.Trigger == nil {
+		writeJSON(w, []struct{}{})
+		return
+	}
+
 	// Read trigger credentials
 	var secretRef aiv1alpha1.SecretKeyRef
 	switch {
@@ -818,24 +903,40 @@ func (s *Server) handleRetryRun(w http.ResponseWriter, r *http.Request) {
 	// Clear history entry so the new run can complete normally
 	if s.history != nil {
 		issueKey := run.Spec.IssueKey
-		if issueKey == "" {
+		if issueKey == "" && run.Spec.IssueNumber > 0 {
 			issueKey = fmt.Sprintf("#%d", run.Spec.IssueNumber)
+		}
+		if issueKey == "" {
+			issueKey = "spot:" + run.Name
 		}
 		_ = s.history.Delete(r.Context(), namespace, run.Spec.PipelineRef, issueKey)
 	}
 
 	// Create new PipelineRun with same spec but fresh metadata
+	labels := map[string]string{
+		"ai.aipipelines.io/pipeline": run.Spec.PipelineRef,
+	}
+	if run.Spec.IssueKey != "" {
+		labels["ai.aipipelines.io/issue-key"] = sanitizeLabelValue(run.Spec.IssueKey)
+	}
+	if run.Spec.Description != "" {
+		labels["ai.aipipelines.io/spot"] = "true"
+	}
+
+	genName := fmt.Sprintf("%s-", run.Spec.PipelineRef)
+	if run.Spec.Description != "" {
+		genName = fmt.Sprintf("%s-spot-", run.Spec.PipelineRef)
+	}
+
 	newRun := &aiv1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", run.Spec.PipelineRef),
+			GenerateName: genName,
 			Namespace:    namespace,
-			Labels: map[string]string{
-				"ai.aipipelines.io/pipeline":  run.Spec.PipelineRef,
-				"ai.aipipelines.io/issue-key": sanitizeLabelValue(run.Spec.IssueKey),
-			},
+			Labels:       labels,
 		},
 		Spec: aiv1alpha1.PipelineRunSpec{
 			PipelineRef: run.Spec.PipelineRef,
+			Description: run.Spec.Description,
 			IssueNumber: run.Spec.IssueNumber,
 			IssueKey:    run.Spec.IssueKey,
 			IssueTitle:  run.Spec.IssueTitle,
@@ -906,8 +1007,11 @@ func (s *Server) handleStopRun(w http.ResponseWriter, r *http.Request) {
 	// Record in history
 	if s.history != nil {
 		issueKey := run.Spec.IssueKey
-		if issueKey == "" {
+		if issueKey == "" && run.Spec.IssueNumber > 0 {
 			issueKey = fmt.Sprintf("#%d", run.Spec.IssueNumber)
+		}
+		if issueKey == "" {
+			issueKey = "spot:" + run.Name
 		}
 		completedAt := now.Time
 		_ = s.history.MarkCompleted(r.Context(), issuehistory.Record{
@@ -1508,6 +1612,7 @@ func toRunResponse(run *aiv1alpha1.PipelineRun) runResponse {
 		Name:         run.Name,
 		Namespace:    run.Namespace,
 		Pipeline:     run.Spec.PipelineRef,
+		Description:  run.Spec.Description,
 		IssueNumber:  run.Spec.IssueNumber,
 		IssueKey:     run.Spec.IssueKey,
 		IssueTitle:   run.Spec.IssueTitle,


### PR DESCRIPTION
- Adds support for pipelines without triggers — "spot pipelines" where runs are created on-demand via the dashboard with a free-text task description
- The Pipeline CRD's trigger field is now optional; pipelines without one show as "Spot" in the dashboard and get a "Create Run" button
- PipelineRun gains a description field (used in prompt templates as {{.Description}}); issue fields (issueNumber, issueTitle) are relaxed to optional

What changed
- CRDs: Trigger becomes an optional pointer; Description added to PipelineRunSpec
- Pipeline controller: nil-guards the trigger pointer, skips poller for spot pipelines
- PipelineRun controller: threads Description through template data, commit messages, and history recording
- Dashboard API: new POST /api/pipelines/{ns}/{name}/runs endpoint; nil-safe trigger access across existing handlers
- Dashboard UI: "Create Run" button + inline form on spot pipeline detail pages; issue column gracefully falls back to showing description
- Sample: config/samples/ai_v1alpha1_pipeline_spot.yaml

<img width="1412" height="544" alt="image" src="https://github.com/user-attachments/assets/c0de1263-48a1-43ab-92be-ee16c6a7be43" />

<img width="1446" height="179" alt="image" src="https://github.com/user-attachments/assets/c3faacb2-1663-440b-a34a-e7f637644f2d" />
