### PR TITLE
feat: add Velero backup/restore to Kind dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,12 +113,16 @@ JIRA_EMAIL_FILE ?= $(HOME)/.jira/email
 
 .PHONY: kind-up
 kind-up: ## Create a Kind cluster and install CRDs.
+	@mkdir -p .data/velero-backups
 	@case "$$($(KIND) get clusters 2>/dev/null)" in \
 		*"$(KIND_CLUSTER)"*) \
 			echo "Kind cluster '$(KIND_CLUSTER)' already exists." ;; \
 		*) \
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
-			$(KIND) create cluster --name $(KIND_CLUSTER) --config hack/kind-config.yaml ;; \
+			tmp=$$(mktemp) && \
+			sed 's|__VELERO_BACKUP_PATH__|$(CURDIR)/.data/velero-backups|' hack/kind-config.yaml > "$$tmp" && \
+			$(KIND) create cluster --name $(KIND_CLUSTER) --config "$$tmp"; \
+			rm -f "$$tmp" ;; \
 	esac
 	@kubectl config use-context kind-$(KIND_CLUSTER) >/dev/null 2>&1 || true
 	$(MAKE) install
@@ -175,12 +179,46 @@ kind-setup: kind-up kind-load-image kind-secrets ## Full Kind setup: cluster, im
 	@echo "Run 'make run' to start the controller."
 
 .PHONY: kind-down
-kind-down: ## Delete the Kind cluster.
+kind-down: ## Take a final backup, then delete the Kind cluster.
+	@if [ -f "$(VELERO)" ] && kubectl get deployment velero -n velero &>/dev/null; then \
+		echo "Taking final backup before cluster deletion..."; \
+		$(VELERO) backup create "pre-delete-$$(date +%Y%m%d-%H%M%S)" --wait || \
+			echo "Warning: backup failed (cluster may be unhealthy). Existing backups on disk are unaffected."; \
+	fi
 	$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: kind-reset
 kind-reset: ## Delete all PipelineRuns (fresh test run).
 	kubectl delete pipelineruns --all
+
+##@ Velero (cluster backup/restore)
+
+.PHONY: velero-setup
+velero-setup: velero-cli ## Deploy MinIO + Velero and create hourly backup schedule.
+	@mkdir -p .data/velero-backups
+	VELERO="$(VELERO)" VELERO_AWS_PLUGIN="velero/velero-plugin-for-aws:$(VELERO_AWS_PLUGIN_VERSION)" \
+		bash hack/velero/setup.sh
+
+.PHONY: velero-backup
+velero-backup: velero-cli ## Create an on-demand backup now.
+	@name="manual-$$(date +%Y%m%d-%H%M%S)"; \
+	$(VELERO) backup create "$$name" --wait; \
+	status=$$($(VELERO) backup get "$$name" -o json | jq -r '.status.phase'); \
+	if [ "$$status" = "Completed" ]; then \
+		echo "Backup '$$name' completed successfully."; \
+	else \
+		echo "ERROR: Backup '$$name' finished with status: $$status" >&2; \
+		echo "Run: $(VELERO) backup logs $$name" >&2; \
+		exit 1; \
+	fi
+
+.PHONY: velero-restore
+velero-restore: velero-cli ## Restore from the latest backup.
+	VELERO="$(VELERO)" bash hack/velero/restore.sh
+
+.PHONY: velero-list
+velero-list: velero-cli ## List all Velero backups.
+	$(VELERO) backup get
 
 ##@ Dashboard
 
@@ -283,10 +321,13 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+VELERO ?= $(LOCALBIN)/velero
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.8.1
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
+VELERO_VERSION ?= v1.15.0
+VELERO_AWS_PLUGIN_VERSION ?= v1.11.0
 
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; \
@@ -331,6 +372,17 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 		$(GOLANGCI_LINT) custom --destination $(LOCALBIN) --name golangci-lint-custom && \
 		mv -f $(LOCALBIN)/golangci-lint-custom $(GOLANGCI_LINT); \
 	} || true
+
+.PHONY: velero-cli
+velero-cli: $(VELERO) ## Download velero CLI locally if necessary.
+$(VELERO): $(LOCALBIN)
+	@[ -f "$(VELERO)" ] || { \
+	echo "Downloading velero $(VELERO_VERSION)..." ; \
+	curl -fsSL "https://github.com/vmware-tanzu/velero/releases/download/$(VELERO_VERSION)/velero-$(VELERO_VERSION)-linux-amd64.tar.gz" | \
+	tar xz -C /tmp && \
+	mv "/tmp/velero-$(VELERO_VERSION)-linux-amd64/velero" "$(VELERO)" && \
+	rm -rf "/tmp/velero-$(VELERO_VERSION)-linux-amd64" ; \
+	}
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/Tiltfile
+++ b/Tiltfile
@@ -9,12 +9,23 @@
 # Ignore generated files and local data to prevent feedback loops
 watch_settings(ignore=['config/crd/bases/', 'bin/', 'cmd/dashboard/dist/', '.data/'])
 
+# --- Velero (cluster backup/restore) ---
+# Sets up MinIO + Velero on first run, then restores from the latest backup.
+# Backups live on the host at .data/velero-backups/ and survive cluster deletion.
+local_resource(
+    'velero',
+    cmd='make velero-setup && make velero-restore',
+    auto_init=True,
+    trigger_mode=TRIGGER_MODE_MANUAL,
+)
+
 # --- CRDs ---
 # Re-install CRDs when API types change
 local_resource(
     'crd-install',
     cmd='make install',
     deps=['api/v1alpha1/'],
+    resource_deps=['velero'],
 )
 
 # --- Pipeline CRs (local/ is gitignored — copy from config/samples/ and fill in your values) ---

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -6,3 +6,6 @@ nodes:
       - |
         kind: KubeletConfiguration
         podMaxPids: -1
+    extraMounts:
+      - hostPath: __VELERO_BACKUP_PATH__
+        containerPath: /var/velero-backups

--- a/hack/velero/credentials-velero
+++ b/hack/velero/credentials-velero
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = minioadmin
+aws_secret_access_key = minioadmin

--- a/hack/velero/minio.yaml
+++ b/hack/velero/minio.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: minio-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ""
+  hostPath:
+    path: /var/velero-backups/minio
+  persistentVolumeReclaimPolicy: Retain
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pvc
+  namespace: velero
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ""
+  volumeName: minio-pv
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: velero
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          command: ["minio", "server", "/data"]
+          env:
+            - name: MINIO_ROOT_USER
+              value: minioadmin
+            - name: MINIO_ROOT_PASSWORD
+              value: minioadmin
+          ports:
+            - containerPort: 9000
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: velero
+spec:
+  ports:
+    - port: 9000
+      targetPort: 9000
+  selector:
+    app: minio

--- a/hack/velero/restore.sh
+++ b/hack/velero/restore.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Restore from the latest completed Velero backup.
+# Safe to run when no backups exist — exits cleanly.
+set -euo pipefail
+
+VELERO="${VELERO:-bin/velero}"
+
+# Wait for backup storage location to sync (so Velero discovers backups on disk)
+echo "Waiting for backup storage location to sync..."
+for _ in $(seq 1 60); do
+    synced=$("$VELERO" backup-location get -o json 2>/dev/null \
+        | jq -r '.status.lastSyncedTime // empty') || true
+    if [ -n "$synced" ] && [ "$synced" != "null" ]; then
+        echo "Backup storage location synced."
+        break
+    fi
+    sleep 2
+done
+
+# Find the latest completed backup
+latest=$("$VELERO" backup get -o json 2>/dev/null | jq -r '
+    [.items[] | select(.status.phase == "Completed")]
+    | sort_by(.status.completionTimestamp)
+    | reverse | .[0].metadata.name // empty
+') || true
+
+if [ -z "$latest" ] || [ "$latest" = "null" ]; then
+    echo "No completed backups found. Starting fresh."
+    exit 0
+fi
+
+echo "Restoring from backup: $latest"
+"$VELERO" restore create --from-backup "$latest" --wait
+echo "Restore complete."

--- a/hack/velero/setup.sh
+++ b/hack/velero/setup.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Idempotent Velero + MinIO setup for Kind dev clusters.
+# Backup data lives on the host at .data/velero-backups/ (via Kind extraMounts),
+# so it survives cluster deletion.
+set -euo pipefail
+
+VELERO="${VELERO:-bin/velero}"
+VELERO_AWS_PLUGIN="${VELERO_AWS_PLUGIN:-velero/velero-plugin-for-aws:v1.10.1}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# 1. Deploy MinIO (idempotent — kubectl apply)
+echo "Deploying MinIO..."
+kubectl apply -f "$SCRIPT_DIR/minio.yaml"
+echo "Waiting for MinIO to be ready..."
+kubectl wait --for=condition=available deployment/minio -n velero --timeout=120s
+
+# 2. Create the "velero" bucket if it doesn't exist
+echo "Ensuring 'velero' bucket exists..."
+kubectl -n velero run minio-bucket-init --rm -i --restart=Never \
+    --image=minio/mc:latest --command -- \
+    sh -c 'until mc alias set minio http://minio:9000 minioadmin minioadmin 2>/dev/null; do sleep 1; done; mc mb --ignore-existing minio/velero'
+
+# 3. Install Velero if not already present
+if kubectl get deployment velero -n velero &>/dev/null; then
+    echo "Velero already installed."
+else
+    echo "Installing Velero..."
+    "$VELERO" install \
+        --provider aws \
+        --bucket velero \
+        --plugins "$VELERO_AWS_PLUGIN" \
+        --backup-location-config region=minio,s3ForcePathStyle=true,s3Url=http://minio.velero.svc:9000 \
+        --secret-file "$SCRIPT_DIR/credentials-velero" \
+        --use-volume-snapshots=false \
+        --wait
+fi
+
+# 4. Wait for the backup storage location to sync (discovers existing backups on host)
+echo "Waiting for backup storage location to sync..."
+for _ in $(seq 1 60); do
+    synced=$("$VELERO" backup-location get -o json 2>/dev/null \
+        | jq -r '.status.lastSyncedTime // empty') || true
+    if [ -n "$synced" ] && [ "$synced" != "null" ]; then
+        echo "Backup storage location synced."
+        break
+    fi
+    sleep 2
+done
+
+# 5. Ensure hourly backup schedule exists
+if "$VELERO" schedule get dev-backup &>/dev/null; then
+    echo "Backup schedule 'dev-backup' already exists."
+else
+    echo "Creating hourly backup schedule (7-day retention)..."
+    "$VELERO" schedule create dev-backup --schedule="0 * * * *" --ttl 168h0m0s
+fi
+
+echo "Velero is ready."


### PR DESCRIPTION
  - Adds Velero + MinIO to the Kind dev environment for periodic backup/restore of K8s resources
  - Backup data persists on the host filesystem (`.data/velero-backups/`) via Kind `extraMounts`, surviving cluster deletion
  - Tiltfile auto-restores from the latest backup on `tilt up`, so recreating a cluster recovers all Pipelines, PipelineRuns, Secrets, etc.
  - `kind-down` takes a final backup before destroying the cluster
  - New Makefile targets: `velero-setup`, `velero-backup`, `velero-restore`, `velero-list`

  ## Motivation

  When a Kind cluster dies or needs recreation, all pipeline state (runs, artifacts, triage results) is lost with no recovery option. This makes it impossible to inspect past runs or debug issues after a cluster
  reset.

  ## How it works

  Host: .data/velero-backups/  (persists across cluster deletions)
       ↕  Kind extraMounts
  Kind node: /var/velero-backups/
       ↕  hostPath PV (static, storageClassName: "")
  MinIO pod  (S3-compatible object store)
       ↕  S3 API
  Velero server  (hourly scheduled backups, 7-day retention)

  ## What's backed up

  - Pipeline and PipelineRun CRs (status, triage results, phases)
  - Secrets (GitHub token, AI credentials, Jira token)
  - All other K8s resources in the cluster

  **Not backed up (yet):** PVC workspace data (cloned repos, artifacts). This would require Velero's node-agent and can be added later.

  ## Test plan

  - [x] `make kind-up` creates cluster with extraMounts for backup persistence
  - [x] `make velero-setup` deploys MinIO + Velero, creates hourly schedule
  - [x] `make velero-backup` creates on-demand backup, fails loudly on error
  - [x] Backup data lands on host filesystem at `.data/velero-backups/`
  - [x] `tilt up` runs Velero setup + restore automatically before CRD install
  - [x] `make kind-down` takes a final backup before cluster deletion